### PR TITLE
feat: run container as a non-root user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Hadolint
-        uses: hadolint/hadolint-action@v1.6.0
+        uses: hadolint/hadolint-action@v2.1.0
   sh-checker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run sh-checker
         uses: luizm/action-sh-checker@master
         env:
@@ -26,7 +26,7 @@ jobs:
         php_version: ["7.4", "8.0", "8.1"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build Docker image
         run: docker build -t nginx-php:${{ matrix.php_version }} --build-arg PHP_VERSION=${{ matrix.php_version }} .
       # TODO: Investigate why I get the error `docker: 'scan' is not a docker command.` on GitHub Actions and re-enable this when possible

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Install buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         php_version: ["7.4", "8.0", "8.1"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Install buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=8.0
+ARG PHP_VERSION=8.1
 FROM php:${PHP_VERSION}-fpm-alpine
 
 # PHP_CPPFLAGS are used by the docker-php-ext-* scripts
@@ -7,7 +7,7 @@ ARG PHP_CPPFLAGS="$PHP_CPPFLAGS"
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 # Install Nginx & PHP packages and extensions
-RUN apk add --no-cache \
+RUN apk add --no-cache --update \
     # Install packages required by PHP/Laravel
     git~=2 \
     icu-dev~=69 \
@@ -34,12 +34,13 @@ RUN apk add --no-cache \
     opcache \
     zip \
     gd \
-    # Setup Nginx directories
-    && mkdir -p /var/run/nginx /var/cache/nginx && chown -R www-data:www-data /var/run/nginx /var/cache/nginx \
+    # Setup Nginx directories and permissions
+    && mkdir -p /var/run/nginx \
+    && chown -R www-data:www-data /var/run/nginx /var/lib/nginx /var/log/nginx \
     # Install the latest version of Composer
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    # Clear apk cache to reduce file size and clutter
-    && rm -rf /var/cache/apk/*
+    # Cleanup
+    && rm -rf /var/cache/apk/* /tmp/*
 
 COPY /config/nginx.conf /etc/nginx/http.d/default.conf
 COPY /config/opcache.ini /usr/local/etc/php/conf.d/php-opocache-cfg.ini
@@ -51,6 +52,6 @@ WORKDIR /var/www/html
 
 EXPOSE 8080 8443
 
-USER www-data
+USER www-data:www-data
 
 ENTRYPOINT ["/etc/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,12 @@ RUN apk add --no-cache --update \
     opcache \
     zip \
     gd \
-    # Setup Nginx directories and permissions
+    # Setup Nginx directories, permissions, and one-off configurations
     && mkdir -p /var/run/nginx \
     && chown -R www-data:www-data /var/run/nginx /var/lib/nginx /var/log/nginx \
+    && sed -i 's|user nginx;|#user www-data;|' /etc/nginx/nginx.conf \
+    && sed -i 's|user =|;user =|' /usr/local/etc/php-fpm.d/www.conf \
+    && sed -i 's|group =|;group =|' /usr/local/etc/php-fpm.d/www.conf \
     # Install the latest version of Composer
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apk add --no-cache \
     opcache \
     zip \
     gd \
-    # Setup Nginx directory
-    && mkdir -p /run/nginx \
+    # Setup Nginx directories
+    && mkdir -p /var/run/nginx /var/cache/nginx && chown -R www-data:www-data /var/run/nginx /var/cache/nginx \
     # Install the latest version of Composer
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     # Clear apk cache to reduce file size and clutter
@@ -49,6 +49,8 @@ COPY --chown=www-data:www-data src/ /var/www/html/public
 
 WORKDIR /var/www/html
 
-EXPOSE 80 443
+EXPOSE 8080 8443
+
+USER www-data
 
 ENTRYPOINT ["/etc/start.sh"]

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ A lightweight combined Nginx/PHP-FPM Docker image.
 
 The following features work out of the box without any configuration:
 
-* `PHP-FPM/OPcache` for fast performance in the browser and on the CLI
-* `Nginx` serves as the web host
-* `msmtp` is installed and configured (see `config/msmtprc`) to send mail locally for testing via apps like `Mailcatcher` which will work out of the box (if Mailcatcher container is titled `mailcatcher`) 
-* `mysql_pdo` is installed as the driver for database connections
-* `gd` is installed for image processing
-* `zip` is installed for items that may need that
-* `composer` is installed and ready to use to setup all your dependencies
+- `PHP-FPM/OPcache` for fast performance in the browser and on the CLI
+- `Nginx` serves as the web host and reverse proxy
+- `msmtp` is installed and configured (see `config/msmtprc`) to send mail locally for testing via apps like `Mailcatcher` which will work out of the box (if Mailcatcher container is titled `mailcatcher`)
+- `mysql_pdo` is installed as the driver for database connections
+- `gd` is installed for image processing
+- `zip` is installed for items that may need that
+- `composer` is installed and ready to use to setup all your dependencies
 
 ## Platforms
 
 This image offers platform support for the following architectures starting from image version `8`:
 
-* linux/amd64
-* linux/arm/v7
-* linux/arm64
+- linux/amd64
+- linux/arm/v7
+- linux/arm64
 
 ## Install
 
@@ -54,7 +54,19 @@ Place the root of your laravel project in `/var/www/html` so that the `public` f
 Want to give this image a spin? Simply run the following:
 
 ```bash
-docker-compose up -d
+docker compose up -d
+```
+
+### Ports
+
+Starting with v10 of this image, ports 8080 and 8443 are exposed instead of 80 and 443 due to the container running as a non-root user. You'll want to either use these ports in your project or map them to `80` and `443` respectively:
+
+```yaml
+services:
+  project:
+    ports:
+      - '80:8080'
+      - '443:8443'
 ```
 
 ## Docker Tags
@@ -62,16 +74,20 @@ docker-compose up -d
 Tags for this image follow the syntax of `PHP_VERSION-IMAGE_VERSION`; for instance, a valid tag would be `7.4-9` signifying to use PHP v7.4 and the 9th version of this image (nginx config, Dockerfile, etc).
 
 **PHP Versions**
+
 - `8.1` - uses the latest release on the PHP 8.1 Alpine track. (Starting with image version `9`)
 - `8.0` - uses the latest release on the PHP 8.0 Alpine track.
 - `7.4` - uses the latest release on the PHP 7.4 Alpine track.
 
 **Image Versions (see CHANGELOG for more details)**
+
+- `10`
 - `9`
 - `8`
 - `7`
 
 **Standalone Tags**
+
 - `latest` - uses the latest release of this image with all defaults.
 - `dev` - the testing branch for this image. Do not use this tag in production.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Want to give this image a spin? Simply run the following:
 docker compose up -d
 ```
 
+Once the container spins up, navigate to `http://localhost:8888` in a browser.
+
 ### Ports
 
 Starting with v10 of this image, ports 8080 and 8443 are exposed instead of 80 and 443 due to the container running as a non-root user. You'll want to either use these ports in your project or map them to `80` and `443` respectively:

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     index index.php index.html index;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
     container_name: "nginx-php"
     build: .
     ports:
-      - "81:8080"
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
     container_name: "nginx-php"
     build: .
     ports:
-      - "8080:8080"
+      - "8888:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
-    nginx-php:
-        container_name: "nginx-php"
-        build: .
-        ports:
-            - "81:80"
+  nginx-php:
+    container_name: "nginx-php"
+    build: .
+    ports:
+      - "81:8080"

--- a/examples/laravel/Dockerfile
+++ b/examples/laravel/Dockerfile
@@ -1,4 +1,4 @@
-FROM justintime50/nginx-php:8.0-8
+FROM justintime50/nginx-php:8.1-10
 
 COPY --chown=www-data:www-data ./src /var/www/html
 


### PR DESCRIPTION
# Summary

Runs the container as a non-root user - `www-data`, which is the same user that owns the website content. This removes the ability to alter the container at runtime due to the loss of root privileges and secures this container.

## Testing

- Ran `ps` inside the container and found all processes were running as `www-data` including the nginx master process. 
- Ran `whoami` inside the container and found that the user had changed from `root` to `www-data`.
- Ensured the website was still accessible

Closes #23 