### PR TITLE
Add pcntl PHP extension for Laravel Horizon support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apk add --no-cache --update \
         opcache \
         pdo_mysql \
         zip \
+        pcntl \
     # Remove dev packages once we're done using them
     && apk del \
         autoconf \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following features work out of the box without any configuration:
 - `Nginx` serves as the web host and reverse proxy
   - Logs located at `/var/log/nginx/`
 - `npm` and `node` are installed for all your Node dependencies and scripts
+- `pcntl` for use by Laravel Horizon
 - `PHP-FPM/OPcache` for fast performance in the browser and on the CLI
 - `Redis` extension is installed for caching
 - `supervisord` is installed for process management (Starting with image version `32`)


### PR DESCRIPTION
## Summary

Adds the `pcntl` PHP extension to support Laravel Horizon and other process control functionality.

## Changes

- Added `pcntl` extension to the PHP installation in Dockerfile
- Updated README.md to document the availability of pcntl for Laravel Horizon

## Motivation

Laravel Horizon requires the `pcntl` extension for process control when managing queues. This is a commonly needed extension for Laravel applications using background job processing.
